### PR TITLE
Crash when improperly calling functions

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -463,6 +463,9 @@ func evalExprs(exprs []ast.Expression, env *object.Environment) []object.Object 
 func applyFunction(function object.Object, args []object.Object, line int) object.Object {
 	switch fn := function.(type) {
 	case *object.Function:
+		if len(args) != len(fn.Parameters) {
+			return newError("Line %d: Wrong number of arguments: expected %d, got %d", line, len(fn.Parameters), len(args))
+		}
 		extendedEnv := extendFunctionEnv(fn, args)
 		evaluated := Eval(fn.Body, extendedEnv)
 		return unwrapReturnValue(evaluated)
@@ -478,11 +481,9 @@ func applyFunction(function object.Object, args []object.Object, line int) objec
 
 func extendFunctionEnv(fn *object.Function, args []object.Object) *object.Environment {
 	env := object.NewEnclosedEnvironment(fn.Env)
-
 	for i, param := range fn.Parameters {
 		env.Set(param.Value, args[i])
 	}
-
 	return env
 }
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -603,6 +603,18 @@ func TestHashIndexExpressions(t *testing.T) {
 			nil,
 		},
 		{
+			`func(){}(1)`,
+			"Line 0: Wrong number of arguments: expected 0, got 1",
+		},
+		{
+			`func(a){a}(0, 0, 0, 0, 0)`,
+			"Line 0: Wrong number of arguments: expected 1, got 5",
+		},
+		{
+			`func(a, b){a + b}()`,
+			"Line 0: Wrong number of arguments: expected 2, got 0",
+		},
+		{
 			`{5: 5}[5]`,
 			5,
 		},
@@ -621,6 +633,8 @@ func TestHashIndexExpressions(t *testing.T) {
 		integer, ok := tt.expected.(int)
 		if ok {
 			testIntegerObject(t, evaluated, int64(integer))
+		} else if errorMsg, ok := tt.expected.(string); ok {
+			testErrorObject(t, evaluated, errorMsg)
 		} else {
 			testNullObject(t, evaluated)
 		}
@@ -666,6 +680,20 @@ func testBooleanObject(t *testing.T, obj object.Object, expected bool) bool {
 	}
 	if result.Value != expected {
 		t.Errorf("object has wrong value. Expected: %t, Got: %t", result.Value, expected)
+		return false
+	}
+
+	return true
+}
+
+func testErrorObject(t *testing.T, obj object.Object, expected string) bool {
+	result, ok := obj.(*object.Error)
+	if !ok {
+		t.Errorf("object is not an Error. Got: %T (%+v)", obj, obj)
+		return false
+	}
+	if result.Message != expected {
+		t.Errorf("object has wrong value. Expected: %q, Got: %q", result.Message, expected)
 		return false
 	}
 

--- a/examples/bug-1.mo
+++ b/examples/bug-1.mo
@@ -1,0 +1,16 @@
+let globalNum = 10;
+
+let sum = func(a, b) {
+  let c = a + b;
+  c + globalNum;
+};
+
+let outer = func() {
+  sum(1, 2) + sum(3, 4) + globalNum;
+};
+
+print(outer() + globalNum);
+
+// Incorrect number of arguments
+print("Expect an error, rather than a segfault :")
+sum();

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -415,15 +415,15 @@ func TestCallingFunctionsWithWrongArguments(t *testing.T) {
 	tests := []vmTestCase{
 		{
 			input:    `func() { 1; }(1);`,
-			expected: `Wrong number of arguments. Expected: 0. Got: 1`,
+			expected: `wrong number of arguments. Expected: 0. Got: 1`,
 		},
 		{
 			input:    `func(a) { a; }();`,
-			expected: `Wrong number of arguments. Expected: 1. Got: 0`,
+			expected: `wrong number of arguments. Expected: 1. Got: 0`,
 		},
 		{
 			input:    `func(a, b) { a + b; }(1);`,
-			expected: `Wrong number of arguments. Expected: 2. Got: 1`,
+			expected: `wrong number of arguments. Expected: 2. Got: 1`,
 		},
 	}
 


### PR DESCRIPTION
Why am I making this PR? :

I was playing with your implementation of monkey the other day and I noticed your tests were broken, but the programs ran fine. 
After some investigating I found that calling functions with an incorrect number of parameters caused the VM to crash.

What did I do? :

- Added the fix (pretty simple) and some tests to ensure that it's catching things correctly. 

- Updated a test that existed in vm_test that was checking against the error strings for an error that was never actually raised, and using the wrong strings sourced from the vm emission of the error (just a capitalization issue.)

- Added a bug-1.mo in the examples. 



